### PR TITLE
Add: sunscreen,tag,sunscreen_tagテーブル作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ node_modules/
 !/app/assets/builds/.keep
 
 /node_modules
+.env

--- a/app/models/sunscreen.rb
+++ b/app/models/sunscreen.rb
@@ -1,0 +1,15 @@
+class Sunscreen < ApplicationRecord
+  has_many :sunscreen_tags
+  has_many :tags, through: :sunscreen_tags
+  enum :spf, { spf_unknown: 0, thirty: 30, forty: 40, fifty: 50, fiftyplus: 55 }
+  enum :pa, { pa_unknown: 0, plus1: 1, plus2: 2, plus3: 3, plus4: 4 }
+
+  validates :name, presence: true, uniqueness: true
+  with_options presence: true do
+    validates :manufacture
+    validates :price
+    validates :spf
+    validates :pa
+    validates :capacity
+  end
+end

--- a/app/models/sunscreen_tag.rb
+++ b/app/models/sunscreen_tag.rb
@@ -1,0 +1,4 @@
+class SunscreenTag < ApplicationRecord
+  belongs_to :tag
+  belongs_to :sunscreen
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ApplicationRecord
+  has_many :sunscreen_tags
+  has_many :sunscreens, through: :sunscreen_tags
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,184 @@
+ja:
+  activerecord:
+    models:
+      sunscreen: '日焼け止め'
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      in: は%{count}の範囲に含めてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/db/migrate/20221223045616_create_sunscreens.rb
+++ b/db/migrate/20221223045616_create_sunscreens.rb
@@ -1,0 +1,16 @@
+class CreateSunscreens < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sunscreens do |t|
+      t.text :name, null: false, unique: true
+      t.string :manufacture, null: false
+      t.integer :price, null: false
+      t.integer :spf, null: false, default: 0
+      t.integer :pa, null: false, default: 0
+      t.text :summary, null: false
+      t.integer :capacity
+
+      t.timestamps
+    end
+    add_index :sunscreens, :name, unique: true
+  end
+end

--- a/db/migrate/20221224005001_create_tags.rb
+++ b/db/migrate/20221224005001_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20221224005549_create_sunscreen_tags.rb
+++ b/db/migrate/20221224005549_create_sunscreen_tags.rb
@@ -1,0 +1,11 @@
+class CreateSunscreenTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sunscreen_tags do |t|
+      t.references :tag, null: false, foreign_key: true
+      t.references :sunscreen, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :sunscreen_tags, [:tag_id, :sunscreen_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_14_111206) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_24_005549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "tweets", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
+  create_table "sunscreen_tags", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "sunscreen_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["sunscreen_id"], name: "index_sunscreen_tags_on_sunscreen_id"
+    t.index ["tag_id", "sunscreen_id"], name: "index_sunscreen_tags_on_tag_id_and_sunscreen_id", unique: true
+    t.index ["tag_id"], name: "index_sunscreen_tags_on_tag_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.text "line_user_id", null: false
-    t.integer "role", default: 0
+  create_table "sunscreens", force: :cascade do |t|
+    t.text "name", null: false
+    t.string "manufacture", null: false
+    t.integer "price", null: false
+    t.integer "spf", default: 0, null: false
+    t.integer "pa", default: 0, null: false
+    t.text "summary", null: false
+    t.integer "capacity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sunscreens_on_name", unique: true
   end
 
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
+  add_foreign_key "sunscreen_tags", "sunscreens"
+  add_foreign_key "sunscreen_tags", "tags"
 end

--- a/spec/factories/sunscreen_tags.rb
+++ b/spec/factories/sunscreen_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :sunscreen_tag do
+    tag { nil }
+    sunscreen { nil }
+  end
+end

--- a/spec/factories/sunscreens.rb
+++ b/spec/factories/sunscreens.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :sunscreen do
+    name { "MyText" }
+    manufacture { "MyText" }
+    price { 1 }
+    SPF { 1 }
+    PA { "MyText" }
+    summary { "MyText" }
+    capacity { 1 }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    name { "MyString" }
+  end
+end

--- a/spec/models/sunscreen_spec.rb
+++ b/spec/models/sunscreen_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Sunscreen, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/sunscreen_tag_spec.rb
+++ b/spec/models/sunscreen_tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SunscreenTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
close #18 
sunscreen,tag,sunscreen_tagテーブル作成しました。
## コメント
``rails g model``コマンドでsunscreen,tag,sunscreen_tagテーブル作成しました。
sunscreen.rbとtag.rbとsunscreen_tag.rbにアソシエーションを追加しました。
コンソールにて確認済みです。
