### PR TITLE
Add: sunscreenテーブルにbrandカラム追加

### DIFF
--- a/app/models/sunscreen.rb
+++ b/app/models/sunscreen.rb
@@ -11,5 +11,6 @@ class Sunscreen < ApplicationRecord
     validates :spf
     validates :pa
     validates :capacity
+    validates :btand
   end
 end

--- a/db/migrate/20221228053105_add_brands_to_sunscreens.rb
+++ b/db/migrate/20221228053105_add_brands_to_sunscreens.rb
@@ -1,0 +1,5 @@
+class AddBrandsToSunscreens < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sunscreens, :brand, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_24_005549) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_28_053105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_24_005549) do
     t.integer "capacity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "brand", null: false
     t.index ["name"], name: "index_sunscreens_on_name", unique: true
   end
 


### PR DESCRIPTION
## 概要
close #45 
## コメント
``rails generate migration AddBrandsToSunscreens brand:string``でbrandカラム作成。
``null :false``を追加してマイグレーションをしました。
brandカラムに``presence: true``のバリデーションを追加しました。