### PR TITLE
Add: Sunscreensテーブルにrakuten_url、rakuten_image_urlカラムを追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -45,3 +45,15 @@
     @apply cursor-pointer hover:bg-stone-100 active:bg-stone-200;
   }
 }
+
+  .purupuru {
+  animation: purupuru 0.1s infinite;
+  }
+  @keyframes purupuru {
+    0% {
+        transform: translate(0px, 0px)
+    }
+    50% {
+        transform: translate(0px, 1px) rotateZ(1deg)
+    }
+  }

--- a/app/models/sunscreen.rb
+++ b/app/models/sunscreen.rb
@@ -2,17 +2,19 @@
 #
 # Table name: sunscreens
 #
-#  id          :bigint           not null, primary key
-#  brand       :string           not null
-#  capacity    :integer
-#  manufacture :string           not null
-#  name        :text             not null
-#  pa          :integer          default("pa_unknown"), not null
-#  price       :integer          not null
-#  spf         :integer          default("spf_unknown"), not null
-#  summary     :text             not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id                :bigint           not null, primary key
+#  brand             :string           not null
+#  capacity          :integer
+#  manufacture       :string           not null
+#  name              :text             not null
+#  pa                :integer          default("pa_unknown"), not null
+#  price             :integer          not null
+#  rakuten_image_url :text
+#  rakuten_url       :text
+#  spf               :integer          default("spf_unknown"), not null
+#  summary           :text             not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/app/views/sunscreens/_sunscreens.html.erb
+++ b/app/views/sunscreens/_sunscreens.html.erb
@@ -2,6 +2,9 @@
   <div class="card shadow bg-base-100 mb-3 mt-5">
     <div class="card-body">
       <h2 class="card-title text-1xl font-bold"><%= sunscreen.name %></h2>
+      <div class="hero min-screen">
+        <%= raw sunscreen.rakuten_image_url %>
+      </div>
       <p>SPF:<%= sunscreen.spf_i18n %></p>
       <p>PA:<%= sunscreen.pa_i18n %></p>
       <p>値段:<%= sunscreen.price %>円</p>

--- a/app/views/sunscreens/search.html.erb
+++ b/app/views/sunscreens/search.html.erb
@@ -29,6 +29,9 @@
         <div class="card shadow bg-base-100 mb-3 mt-5">
           <div class="card-body">
             <h2 class="card-title text-1xl font-bold"><%= sunscreen.name %></h2>
+            <div class="hero min-screen">
+              <%= raw @sunscreen.rakuten_image_url %>
+            </div>
             <p>SPF:<%= sunscreen.spf_i18n %></p>
             <p>PA:<%= sunscreen.pa_i18n %></p>
             <p>値段:<%= sunscreen.price %>円</p>

--- a/app/views/sunscreens/show.html.erb
+++ b/app/views/sunscreens/show.html.erb
@@ -4,6 +4,9 @@
     <h1 class="text-3xl font-bold text-center mb-4">
       <%= @sunscreen.name %>
     </h1>
+    <div class="hero min-screen">
+        <%= raw @sunscreen.rakuten_image_url %>
+    </div>
     <p class="font-bold mb-4 mt-4 text-center">
       <%=  Sunscreen.human_attribute_name(:manufacture) %>:<%= @sunscreen.manufacture %>
     </p>
@@ -30,11 +33,16 @@
     </p>
     <p class="font-bold mb-4 text-center">
       <%= Tag.model_name.human %>:
-      <% @sunscreen.tags.each do |tag| %>
-        <%= tag.name %>
-      <% end %>
+        <% @sunscreen.tags.each do |tag| %>
+          <span class="text-xs font-semibold inline-block py-1 px-2 uppercase rounded-full text-sky-600 bg-sky-200 uppercase last:mr-0 mr-1">
+            <%= link_to tag.name, search_sunscreens_path(tag_id: tag.id) %>
+          </span>
+        <% end %>
     </p>
-    <div class="link text-center">
+    <div class="link text-center mt-5">
+      <%= link_to '⭐️楽天で購入する⭐️', url_for(@sunscreen.rakuten_url), class: "purupuru btn btn-wide text-center bg-orange-400 hover:bg-orange-300 text-black border-0 mt-5 mb-4"%>
+    </div>
+    <div class="link text-center pt-5">
       <%= link_to "日焼け止め一覧へ", sunscreens_path, class: "btn btn-wide text-center bg-orange-400 hover:bg-orange-300 text-black border-0 mt-5 mb-4" %>
     </div>
   </div>

--- a/db/migrate/20230514055930_add_rakuten_url_to_sunscreens.rb
+++ b/db/migrate/20230514055930_add_rakuten_url_to_sunscreens.rb
@@ -1,0 +1,6 @@
+class AddRakutenUrlToSunscreens < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sunscreens, :rakuten_url, :text
+    add_column :sunscreens, :rakuten_image_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_21_045842) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_14_055930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_21_045842) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "brand", null: false
+    t.text "rakuten_url"
+    t.text "rakuten_image_url"
     t.index ["name"], name: "index_sunscreens_on_name", unique: true
   end
 

--- a/spec/factories/sunscreens.rb
+++ b/spec/factories/sunscreens.rb
@@ -2,17 +2,19 @@
 #
 # Table name: sunscreens
 #
-#  id          :bigint           not null, primary key
-#  brand       :string           not null
-#  capacity    :integer
-#  manufacture :string           not null
-#  name        :text             not null
-#  pa          :integer          default("pa_unknown"), not null
-#  price       :integer          not null
-#  spf         :integer          default("spf_unknown"), not null
-#  summary     :text             not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id                :bigint           not null, primary key
+#  brand             :string           not null
+#  capacity          :integer
+#  manufacture       :string           not null
+#  name              :text             not null
+#  pa                :integer          default("pa_unknown"), not null
+#  price             :integer          not null
+#  rakuten_image_url :text
+#  rakuten_url       :text
+#  spf               :integer          default("spf_unknown"), not null
+#  summary           :text             not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/sunscreen_spec.rb
+++ b/spec/models/sunscreen_spec.rb
@@ -2,17 +2,19 @@
 #
 # Table name: sunscreens
 #
-#  id          :bigint           not null, primary key
-#  brand       :string           not null
-#  capacity    :integer
-#  manufacture :string           not null
-#  name        :text             not null
-#  pa          :integer          default("pa_unknown"), not null
-#  price       :integer          not null
-#  spf         :integer          default("spf_unknown"), not null
-#  summary     :text             not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id                :bigint           not null, primary key
+#  brand             :string           not null
+#  capacity          :integer
+#  manufacture       :string           not null
+#  name              :text             not null
+#  pa                :integer          default("pa_unknown"), not null
+#  price             :integer          not null
+#  rakuten_image_url :text
+#  rakuten_url       :text
+#  spf               :integer          default("spf_unknown"), not null
+#  summary           :text             not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #


### PR DESCRIPTION
## 概要
close #125
## コメント
日焼け止めの画像と商品購入リンクをアプリから参照できるようにしました。
Sunscreensテーブルにrakuten_urlカラム、rakuten_image_urlカラムを追加しました。
